### PR TITLE
Delete unused nuget dependence Avalonia.Desktop

### DIFF
--- a/AvaloniaDialogs/AvaloniaDialogs.csproj
+++ b/AvaloniaDialogs/AvaloniaDialogs.csproj
@@ -23,8 +23,6 @@
 	<ItemGroup>
 		<PackageReference Include="Avalonia"
 						  Version="11.1.0" />
-		<PackageReference Include="Avalonia.Desktop"
-						  Version="11.1.0" />
 		<PackageReference Include="DialogHost.Avalonia"
 						  Version="0.8.1" />
 	</ItemGroup>


### PR DESCRIPTION
This library doesn't need Avalonia.Desktop, and the latter will also prevent the compilation for browser [link](https://github.com/AvaloniaUI/Avalonia/discussions/9264).